### PR TITLE
FlexLLama v0.1.7: Fixed auto model unload

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -7,5 +7,5 @@ This package provides functionality for managing and running llama.cpp models.
 from .config import ConfigManager
 from .runner import RunnerManager, RunnerProcess
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __all__ = ["ConfigManager", "RunnerManager", "RunnerProcess"]

--- a/backend/runner.py
+++ b/backend/runner.py
@@ -354,7 +354,7 @@ class RunnerProcess:
                         f"Runner {self.runner_name} started successfully with model {model_alias}"
                     )
                     self.current_model = model_config
-                    self.last_activity_ts = None
+                    self.last_activity_ts = time.time()
                     self.active_requests = 0
                     self.is_starting = False
                     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flexllama"
-version = "0.1.6"
+version = "0.1.7"
 description = "A lightweight Python tool that easily runs multiple llama.cpp server instances with OpenAI v1 API compatibility"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
## Overview
Critical patch fixing auto-unload functionality for auto-started models.

## 🔧 Bug Fixes

### Auto-Unload Mechanism Fixed
**Fixed**: Models with `auto_start_runners: true` now properly auto-unload after configured timeout. Previously, auto-started models would never unload due to `last_activity_ts` being incorrectly set to `None`.

**Impact**: Consistent auto-unload behavior regardless of how models are loaded, improving resource management for long-running instances.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `last_activity_ts` when a runner finishes starting to enable proper auto-unload; bump version to 0.1.7.
> 
> - **Backend**:
>   - Set `last_activity_ts = time.time()` when server becomes ready in `backend/runner.py` to ensure idle auto-unload works for auto-started models.
> - **Versioning**:
>   - Bump package version from `0.1.6` to `0.1.7` in `backend/__init__.py` and `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262a2a3e5d2b3383ecf44cd0a135765968b785a5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->