### PR TITLE
FlexLLama 0.1.10: CORS support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -155,6 +155,36 @@ FlexLLama supports configurable timeouts for long-running requests:
 
 **Note:** The server keepalive timeout is set to 60 minutes by default to support long-running model inference.
 
+## CORS Configuration
+
+By default FlexLLama does **not** emit CORS headers, so browser-based clients
+loaded from a different origin cannot call the API. This is the safe default:
+allowing cross-origin access means any website a user visits can script
+requests against their FlexLLama instance (which has no authentication).
+
+To opt in, set `api.cors_allow_origins` to a list of origins:
+
+```json
+{
+    "api": {
+        "host": "0.0.0.0",
+        "port": 8080,
+        "cors_allow_origins": ["http://localhost:5173", "https://my-chat-ui.example"]
+    }
+}
+```
+
+- `[]` (default): CORS disabled. Recommended when FlexLLama is only called
+  from same-origin pages or from non-browser clients.
+- `["*"]`: Allow any origin (non-credentialed). Convenient for local dev;
+  understand that any page in any browser on your network can then call
+  the API.
+- Explicit list: The request `Origin` header must match exactly; the server
+  reflects it and sets `Vary: Origin`. Preferred for production.
+
+`Access-Control-Allow-Credentials` is never set, so browser cookies are not
+forwarded cross-origin regardless of this setting.
+
 ## Configuration Options Reference
 
 ### Runner Options

--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ The `tests/` directory contains scripts for different testing purposes. All test
 ```bash
 # Run basic tests against the default URL (http://localhost:8080)
 python tests/test_basic.py
+
+# Additionally verify CORS response headers (requires
+# api.cors_allow_origins to be configured on the server)
+python tests/test_basic.py --cors-origin '*'
 ```
 
 **What it tests:**
@@ -333,6 +337,8 @@ python tests/test_basic.py
 - `/v1/models` and `/health` endpoints
 - `/v1/chat/completions` with both regular and streaming responses
 - Concurrent request handling
+- Optional: CORS headers on preflight, regular, and streaming responses
+  when invoked with `--cors-origin`
 
 #### All Models Test
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -47,8 +47,22 @@ class APIServer:
         # Get frontend directory path - try package resources first, fallback to relative path
         self.frontend_path = self._get_frontend_path()
 
+        # Load CORS configuration before building the application so the middleware
+        # can be registered with the right allowlist.
+        self.cors_allow_origins = config_manager.get_cors_allow_origins()
+
         # Set a larger client_max_size to handle image uploads (10MB should be enough)
-        self.app = web.Application(client_max_size=10 * 1024 * 1024)
+        self.app = web.Application(
+            client_max_size=10 * 1024 * 1024,
+            middlewares=[self._build_cors_middleware()],
+        )
+        # CORS responsibilities are split: the middleware answers preflight
+        # (OPTIONS) directly, and on_response_prepare attaches the
+        # Access-Control-Allow-Origin header to every other response. The
+        # signal is used instead of mutating the response after the handler
+        # returns because StreamResponse.prepare() flushes headers immediately,
+        # so post-handler mutation never reaches streaming clients.
+        self.app.on_response_prepare.append(self._apply_cors_headers)
 
         # Set keepalive timeout to 60 minutes for long-running requests
         self.keepalive_timeout = 3600  # 60 minutes
@@ -88,7 +102,6 @@ class APIServer:
             web.post("/v1/embeddings", self.handle_embeddings),
             web.post("/v1/rerank", self.handle_rerank),
             web.post("/v1/responses", self.handle_responses),
-            web.options("/{tail:.*}", self.handle_options),
             # Runner control routes
             web.post("/v1/runners/{runner_name}/start", self.handle_runner_start),
             web.post("/v1/runners/{runner_name}/stop", self.handle_runner_stop),
@@ -197,21 +210,72 @@ class APIServer:
                     f"Request ended for model {model_alias}, active requests: {runner.active_requests}"
                 )
 
-    async def handle_options(self, request):
-        """Handle OPTIONS requests for CORS.
+    def _build_cors_middleware(self):
+        """Build an aiohttp middleware that answers CORS preflight requests.
 
-        Args:
-            request: The request.
+        Non-preflight responses get their CORS headers from
+        _apply_cors_headers via the on_response_prepare signal; this
+        middleware only short-circuits OPTIONS so preflight never reaches
+        the regular handlers.
 
-        Returns:
-            The response.
+        Access-Control-Allow-Credentials is intentionally NOT set: combining
+        it with "*" is invalid, and enabling it by default would let any
+        allowed origin read authenticated responses. Operators who need
+        credentialed CORS can extend this later with an explicit config flag.
         """
-        headers = {
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type",
-        }
-        return web.Response(status=200, headers=headers)
+        @web.middleware
+        async def cors_middleware(request, handler):
+            if request.method == "OPTIONS":
+                origin = self._resolve_cors_origin(request)
+                headers = {}
+                if origin:
+                    headers["Access-Control-Allow-Origin"] = origin
+                    if origin != "*":
+                        headers["Vary"] = "Origin"
+                    # Echo the headers the client asked to send so Authorization
+                    # (used by OpenAI-compatible clients) passes preflight.
+                    requested_headers = request.headers.get(
+                        "Access-Control-Request-Headers", "Content-Type, Authorization"
+                    )
+                    headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+                    headers["Access-Control-Allow-Headers"] = requested_headers
+                    headers["Access-Control-Max-Age"] = "600"
+                return web.Response(status=200, headers=headers)
+
+            # Non-preflight: actual CORS header is set by on_response_prepare
+            # so it also reaches the client for streaming responses.
+            return await handler(request)
+
+        return cors_middleware
+
+    def _resolve_cors_origin(self, request):
+        """Resolve the Access-Control-Allow-Origin value for a request, or None."""
+        allow_origins = self.cors_allow_origins
+        if not allow_origins:
+            return None
+        if allow_origins == ["*"]:
+            return "*"
+        request_origin = request.headers.get("Origin")
+        if request_origin and request_origin in allow_origins:
+            return request_origin
+        return None
+
+    async def _apply_cors_headers(self, request, response):
+        """Attach CORS headers just before response headers are flushed.
+
+        Runs on the on_response_prepare signal so that streaming endpoints
+        (which call StreamResponse.prepare() and flush headers immediately)
+        also emit Access-Control-Allow-Origin.
+        """
+        origin = self._resolve_cors_origin(request)
+        if not origin:
+            return
+        response.headers["Access-Control-Allow-Origin"] = origin
+        if origin != "*":
+            existing_vary = response.headers.get("Vary")
+            response.headers["Vary"] = (
+                f"{existing_vary}, Origin" if existing_vary else "Origin"
+            )
 
     async def handle_dashboard(self, request):
         """Handle GET / and /dashboard requests to serve the dashboard.

--- a/backend/config.py
+++ b/backend/config.py
@@ -551,6 +551,26 @@ class ConfigManager:
         """
         return self.config.get("api", {}).get("health_endpoint", "/health")
 
+    def get_cors_allow_origins(self):
+        """Get the list of CORS allowed origins for the API server.
+
+        Returns:
+            A list of allowed origins. The special value ["*"] allows any origin
+            (non-credentialed). An empty list disables CORS headers entirely.
+            Defaults to [] (CORS off): operators must opt in explicitly because
+            enabling CORS broadens the attack surface to any website loaded in
+            a user's browser. Prior releases emitted Access-Control-Allow-Origin
+            only on OPTIONS preflight, so cross-origin requests never actually
+            worked in practice and this default preserves that effective state.
+        """
+        api_config = self.config.get("api", {})
+        origins = api_config.get("cors_allow_origins", [])
+        if isinstance(origins, str):
+            origins = [origins]
+        if not isinstance(origins, list):
+            raise ValueError("api.cors_allow_origins must be a list of strings or a single string")
+        return [str(o) for o in origins]
+
     def get_runner_host(self, runner_name: str):
         """Get the host for a specific runner.
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -176,6 +176,117 @@ async def test_health_endpoint(base_url):
             return None
 
 
+async def test_cors_headers(base_url, model, expected_origin):
+    """Verify CORS headers on preflight, regular, and streaming responses.
+
+    Only runs when the operator passes --cors-origin, since CORS is opt-in
+    via the api.cors_allow_origins config option. The test covers the three
+    code paths that CORS touches separately:
+
+    - OPTIONS preflight answered by the middleware short-circuit.
+    - Regular JSON response (GET /v1/models) getting its header from the
+      on_response_prepare signal.
+    - Streaming response (POST /v1/chat/completions with stream=true),
+      which flushes headers via StreamResponse.prepare() and used to miss
+      the CORS header prior to the on_response_prepare wiring.
+
+    Args:
+        base_url: The base URL of the API server.
+        model: A model alias to exercise the streaming endpoint with.
+        expected_origin: The origin value expected in Access-Control-Allow-Origin.
+            Use "*" when the server is configured with cors_allow_origins=["*"],
+            otherwise the exact origin string the client is sending.
+
+    Returns:
+        True if all three checks pass, False otherwise.
+    """
+    logger.info("Testing CORS headers (expected origin: %s)", expected_origin)
+    client_origin = "http://flexllama-test.invalid" if expected_origin == "*" else expected_origin
+    timeout = aiohttp.ClientTimeout(total=30)
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        # 1. Preflight
+        preflight_headers = {
+            "Origin": client_origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization, content-type",
+        }
+        try:
+            async with session.options(
+                f"{base_url}/v1/chat/completions", headers=preflight_headers
+            ) as response:
+                allow_origin = response.headers.get("Access-Control-Allow-Origin")
+                allow_headers = response.headers.get("Access-Control-Allow-Headers", "")
+                if allow_origin != expected_origin:
+                    logger.error(
+                        "Preflight Access-Control-Allow-Origin mismatch: got %r, expected %r",
+                        allow_origin,
+                        expected_origin,
+                    )
+                    return False
+                allow_headers_lower = allow_headers.lower()
+                for requested in ("authorization", "content-type"):
+                    if requested not in allow_headers_lower:
+                        logger.error(
+                            "Preflight did not echo %s in Access-Control-Allow-Headers: %r",
+                            requested,
+                            allow_headers,
+                        )
+                        return False
+        except Exception as e:
+            logger.error("Preflight request failed: %s", e)
+            return False
+
+        # 2. Regular JSON response
+        try:
+            async with session.get(
+                f"{base_url}/v1/models", headers={"Origin": client_origin}
+            ) as response:
+                allow_origin = response.headers.get("Access-Control-Allow-Origin")
+                if allow_origin != expected_origin:
+                    logger.error(
+                        "GET /v1/models Access-Control-Allow-Origin mismatch: got %r, expected %r",
+                        allow_origin,
+                        expected_origin,
+                    )
+                    return False
+        except Exception as e:
+            logger.error("GET /v1/models failed: %s", e)
+            return False
+
+        # 3. Streaming response (header must arrive before the body starts)
+        stream_payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": "Reply with the single word OK."}],
+            "stream": True,
+            "max_tokens": 8,
+        }
+        try:
+            async with session.post(
+                f"{base_url}/v1/chat/completions",
+                headers={"Origin": client_origin, "Content-Type": "application/json"},
+                json=stream_payload,
+            ) as response:
+                allow_origin = response.headers.get("Access-Control-Allow-Origin")
+                if allow_origin != expected_origin:
+                    logger.error(
+                        "Streaming /v1/chat/completions Access-Control-Allow-Origin mismatch: "
+                        "got %r, expected %r",
+                        allow_origin,
+                        expected_origin,
+                    )
+                    return False
+                # Drain a few bytes so the server can finish cleanly.
+                async for _ in response.content.iter_chunked(1024):
+                    break
+        except Exception as e:
+            logger.error("Streaming request failed: %s", e)
+            return False
+
+    logger.info("CORS headers verified on preflight, GET, and streaming POST")
+    return True
+
+
 async def test_chat_completions(base_url, model):
     """Test the /v1/chat/completions endpoint.
 
@@ -369,6 +480,17 @@ async def main():
         "--url", default="http://localhost:8080", help="Base URL of the API server"
     )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    parser.add_argument(
+        "--cors-origin",
+        default=None,
+        help=(
+            "When set, verify CORS response headers against this expected "
+            "Access-Control-Allow-Origin value. Use '*' if the server is "
+            "configured with cors_allow_origins=['*'], otherwise the exact "
+            "origin string that is allowlisted. Skip the flag when CORS is "
+            "disabled server-side."
+        ),
+    )
     args = parser.parse_args()
 
     # Set up test logging
@@ -418,6 +540,14 @@ async def main():
         if not await test_streaming_chat_completions(args.url, test_model):
             logger.warning(f"Streaming test failed for model {test_model}")
 
+        # Optional: verify CORS headers when the server is configured for them.
+        if args.cors_origin:
+            logger.info("=" * 60)
+            logger.info("Testing CORS headers")
+            logger.info("=" * 60)
+            if not await test_cors_headers(args.url, test_model, args.cors_origin):
+                logger.error("CORS header test failed")
+                sys.exit(1)
         # Test concurrent requests across different runners (if multiple runners are active)
         logger.info("=" * 60)
         logger.info("Testing concurrent requests across runners")


### PR DESCRIPTION
## Overview
This release adds configurable CORS support, enabling browser-based clients from different origins to access the FlexLLama API. The feature introduces a new `api.cors_allow_origins` configuration option, proper OPTIONS preflight handling, and CORS headers on all response types including streaming.

## 🚀 New Features

### CORS Configuration Support
**Added**: New `api.cors_allow_origins` config option that allows operators to opt in to cross-origin requests. The API server now uses an aiohttp middleware to handle CORS preflight (OPTIONS) requests and the `on_response_prepare` signal to attach `Access-Control-Allow-Origin` headers to all responses, including streaming endpoints. CORS is disabled by default for security—operators must explicitly configure allowed origins. Supports wildcard (`["*"]`) for local development or an explicit list of origins for production use.

**Impact**: Browser-based chat UIs and other cross-origin clients can now interact with FlexLLama when CORS is enabled. The fix also resolves the prior issue where CORS headers only appeared on preflight responses but were missing from actual responses and streaming chunks.

Bring your web clients closer to local inference with FlexLLama v0.1.10!